### PR TITLE
bugfix: Enpty string

### DIFF
--- a/sound_keyboard/sound/sound.py
+++ b/sound_keyboard/sound/sound.py
@@ -3,6 +3,8 @@ from io import BytesIO
 from mpg123 import Mpg123, Out123
 
 def read_aloud(text : str):
+    if len(text) <= 0: return
+
     fp = BytesIO()
     tts = gTTS(text, lang="ja")
     tts.write_to_fp(fp)


### PR DESCRIPTION
# 概要
空文字入力の際に終了するバグの対処

# 原因
gTTSが空文字列を渡されたときに対処できない。

# 対処法
文字列の長さを確認し，0文字だった場合に何も実行せず終了するガード節の挿入。